### PR TITLE
因为添加embed模块没更新go.mod导致无法正常编译报错

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shadow1ng/fscan
 
-go 1.15
+go 1.16
 
 require (
 	github.com/antlr/antlr4 v0.0.0-20200503195918-621b933c7a7f // indirect


### PR DESCRIPTION
因为添加embed模块为更没go.mod导致无法正常编译报错