### PR TITLE
修复 -p 参数在某些情况下以范围指定端口时(如 -p 8000-10000)解析错误问题

### DIFF
--- a/common/ParsePort.go
+++ b/common/ParsePort.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"sort"
 	"strconv"
 	"strings"
 )
@@ -17,9 +16,17 @@ func ParsePort(ports string) []int {
 			if len(ranges) < 2 {
 				continue
 			}
-			sort.Strings(ranges)
-			port = ranges[0]
-			upper = ranges[1]
+
+			startPort, _ := strconv.Atoi(ranges[0])
+			endPort, _ := strconv.Atoi(ranges[1])
+			if startPort < endPort {
+				port = ranges[0]
+				upper = ranges[1]
+			} else {
+				port = ranges[1]
+				upper = ranges[0]
+			}
+
 		}
 		start, _ := strconv.Atoi(port)
 		end, _ := strconv.Atoi(upper)


### PR DESCRIPTION
修改了使用 common/ParsePort.go 文件中使用 sort.Strings(ranges) 进行排序的一个BUG，在某些端口范围下，导致端口解析出错，例如
ranges = [8000,10000]
sort.Strings(ranges) 返回结果为 [10000,8000] 导致无法进入后面的 for 循环以获取端口列表