### PR TITLE
Update check.go

### DIFF
--- a/WebScan/lib/check.go
+++ b/WebScan/lib/check.go
@@ -221,7 +221,7 @@ func doSearch(re string, body string) map[string]string {
 
 func newReverse() *Reverse {
 	letters := "1234567890abcdefghijklmnopqrstuvwxyz"
-	randSource := rand.New(rand.NewSource(time.Now().Unix()))
+	randSource := rand.New(rand.NewSource(time.Now().UnixNano()))
 	sub := RandomStr(randSource, letters, 8)
 	//if true {
 	//	//默认不开启dns解析


### PR DESCRIPTION
使用毫秒作为随机数种子，避免生成的ceye子域名相同，导致反连平台误报