### PR TITLE
支持mongodb6.0未授权扫描

### DIFF
--- a/Plugins/mongodb.go
+++ b/Plugins/mongodb.go
@@ -2,7 +2,6 @@ package Plugins
 
 import (
 	"fmt"
-	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/shadow1ng/fscan/common"
 	"strings"
 	"time"
@@ -22,32 +21,67 @@ func MongodbScan(info *common.HostInfo) error {
 
 func MongodbUnauth(info *common.HostInfo) (flag bool, err error) {
 	flag = false
-	senddata := []byte{72, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 212, 7, 0, 0, 0, 0, 0, 0, 97, 100, 109, 105, 110, 46, 36, 99, 109, 100, 0, 0, 0, 0, 0, 1, 0, 0, 0, 33, 0, 0, 0, 2, 103, 101, 116, 76, 111, 103, 0, 16, 0, 0, 0, 115, 116, 97, 114, 116, 117, 112, 87, 97, 114, 110, 105, 110, 103, 115, 0, 0}
+	// op_msg
+	packet1 := []byte{
+		0x69, 0x00, 0x00, 0x00, // messageLength
+		0x39, 0x00, 0x00, 0x00, // requestID
+		0x00, 0x00, 0x00, 0x00, // responseTo
+		0xdd, 0x07, 0x00, 0x00, // opCode OP_MSG
+		0x00, 0x00, 0x00, 0x00, // flagBits
+		// sections db.adminCommand({getLog: "startupWarnings"})
+		0x00, 0x54, 0x00, 0x00, 0x00, 0x02, 0x67, 0x65, 0x74, 0x4c, 0x6f, 0x67, 0x00, 0x10, 0x00, 0x00, 0x00, 0x73, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x57, 0x61, 0x72, 0x6e, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x02, 0x24, 0x64, 0x62, 0x00, 0x06, 0x00, 0x00, 0x00, 0x61, 0x64, 0x6d, 0x69, 0x6e, 0x00, 0x03, 0x6c, 0x73, 0x69, 0x64, 0x00, 0x1e, 0x00, 0x00, 0x00, 0x05, 0x69, 0x64, 0x00, 0x10, 0x00, 0x00, 0x00, 0x04, 0x6e, 0x81, 0xf8, 0x8e, 0x37, 0x7b, 0x4c, 0x97, 0x84, 0x4e, 0x90, 0x62, 0x5a, 0x54, 0x3c, 0x93, 0x00, 0x00,
+	}
+	//op_query
+	packet2 := []byte{
+		0x48, 0x00, 0x00, 0x00, // messageLength
+		0x02, 0x00, 0x00, 0x00, // requestID
+		0x00, 0x00, 0x00, 0x00, // responseTo
+		0xd4, 0x07, 0x00, 0x00, // opCode OP_QUERY
+		0x00, 0x00, 0x00, 0x00, // flags
+		0x61, 0x64, 0x6d, 0x69, 0x6e, 0x2e, 0x24, 0x63, 0x6d, 0x64, 0x00, // fullCollectionName admin.$cmd
+		0x00, 0x00, 0x00, 0x00, // numberToSkip
+		0x01, 0x00, 0x00, 0x00, // numberToReturn
+		// query db.adminCommand({getLog: "startupWarnings"})
+		0x21, 0x00, 0x00, 0x00, 0x2, 0x67, 0x65, 0x74, 0x4c, 0x6f, 0x67, 0x00, 0x10, 0x00, 0x00, 0x00, 0x73, 0x74, 0x61, 0x72, 0x74, 0x75, 0x70, 0x57, 0x61, 0x72, 0x6e, 0x69, 0x6e, 0x67, 0x73, 0x00, 0x00,
+	}
+
 	realhost := fmt.Sprintf("%s:%v", info.Host, info.Ports)
-	conn, err := common.WrapperTcpWithTimeout("tcp", realhost, time.Duration(common.Timeout)*time.Second)
-	defer func() {
-		if conn != nil {
-			conn.Close()
+
+	checkUnAuth := func(address string, packet []byte) (string, error) {
+		conn, err := common.WrapperTcpWithTimeout("tcp", realhost, time.Duration(common.Timeout)*time.Second)
+		if err != nil {
+			return "", err
 		}
-	}()
-	if err != nil {
-		return flag, err
+		defer func() {
+			if conn != nil {
+				conn.Close()
+			}
+		}()
+		err = conn.SetReadDeadline(time.Now().Add(time.Duration(common.Timeout) * time.Second))
+		if err != nil {
+			return "", err
+		}
+		_, err = conn.Write(packet)
+		if err != nil {
+			return "", err
+		}
+		reply := make([]byte, 1024)
+		count, err := conn.Read(reply)
+		if err != nil {
+			return "", err
+		}
+		return string(reply[0:count]), nil
 	}
-	err = conn.SetReadDeadline(time.Now().Add(time.Duration(common.Timeout) * time.Second))
+
+	// send OP_MSG first
+	reply, err := checkUnAuth(realhost, packet1)
 	if err != nil {
-		return flag, err
+		reply, err = checkUnAuth(realhost, packet2)
+		if err != nil {
+			return flag, err
+		}
 	}
-	_, err = conn.Write(senddata)
-	if err != nil {
-		return flag, err
-	}
-	buf := make([]byte, 1024)
-	count, err := conn.Read(buf)
-	if err != nil {
-		return flag, err
-	}
-	text := string(buf[0:count])
-	if strings.Contains(text, "totalLinesWritten") {
+	if strings.Contains(reply, "totalLinesWritten") {
 		flag = true
 		result := fmt.Sprintf("[+] Mongodb:%v unauthorized", realhost)
 		common.LogSuccess(result)


### PR DESCRIPTION
mongo6之后，`OP_QUERY` 数据包不再支持 `getLog` ，改为优先使用 `OP_MSG` 方式检测