### PR TITLE
修复获取WebTitle的Bug

### DIFF
--- a/Plugins/webtitle.go
+++ b/Plugins/webtitle.go
@@ -197,7 +197,7 @@ func getRespBody(oResp *http.Response) ([]byte, error) {
 }
 
 func gettitle(body []byte) (title string) {
-	re := regexp.MustCompile("(?ims)<title>(.*?)</title>")
+	re := regexp.MustCompile("(?ims)<title.*?>(.*?)</title>")
 	find := re.FindSubmatch(body)
 	if len(find) > 1 {
 		title = string(find[1])


### PR DESCRIPTION
测试资产FOFA：title="Vaultwarden Web Vault"

<title page-title>Vaultwarden Web Vault</title>

修复在title标签有属性时获取不到标题的bug