### PR TITLE
优化存活主机输出顺序

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result.txt
+.idea

--- a/Plugins/scanner.go
+++ b/Plugins/scanner.go
@@ -25,7 +25,6 @@ func Scan(info common.HostInfo) {
 	if len(Hosts) > 0 || len(common.HostPort) > 0 {
 		if common.NoPing == false && len(Hosts) > 1 || common.Scantype == "icmp" {
 			Hosts = CheckLive(Hosts, common.Ping)
-			fmt.Println("[*] Icmp alive hosts len is:", len(Hosts))
 		}
 		if common.Scantype == "icmp" {
 			common.LogWG.Wait()


### PR DESCRIPTION
优化存活主机输出顺序 按照ip顺序输出， 如下图
另外shadow师傅，Releases里面编译用的go版本太高了，win7和低版本win server报错跑不了
原因是go的1.21版本放弃了对Windows全版本的支持，建议用go 1.20的
参考 https://go.dev/doc/go1.20#windows


![image](https://github.com/shadow1ng/fscan/assets/94220731/526c3279-5b39-4f1b-9f2f-073b7dd0c3be)
