### PR TITLE
fix: 修复中文标题截取导致乱码的问题

### DIFF
--- a/Plugins/webtitle.go
+++ b/Plugins/webtitle.go
@@ -210,8 +210,9 @@ func gettitle(body []byte) (title string) {
 		title = strings.Replace(title, "\n", "", -1)
 		title = strings.Replace(title, "\r", "", -1)
 		title = strings.Replace(title, "&nbsp;", " ", -1)
-		if len(title) > 100 {
-			title = title[:100]
+		titleRune := []rune(title)
+		if len(titleRune) > 5 {
+			title = string(titleRune[:100])
 		}
 		if title == "" {
 			title = "\"\"" //空格


### PR DESCRIPTION
由于我需要写入数据库， 但是字符乱码导致 写入数据库报错了
<img width="1029" alt="Snipaste_2024-11-03_17-17-13" src="https://github.com/user-attachments/assets/13d2db4f-60cf-40ab-a718-83b06ac4f526">
<img width="739" alt="Snipaste_2024-11-03_17-19-45" src="https://github.com/user-attachments/assets/3e3b9c19-79e6-437c-ab80-70f680e998cd">

