### PR TITLE
feat: tcp端口扫描支持socks5

### DIFF
--- a/Common/Proxy.go
+++ b/Common/Proxy.go
@@ -1,19 +1,28 @@
 package Common
 
 import (
+	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
-	"golang.org/x/net/proxy"
 	"net"
 	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/net/proxy"
 )
 
 // WrapperTcpWithTimeout 创建一个带超时的TCP连接
 func WrapperTcpWithTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
 	d := &net.Dialer{Timeout: timeout}
 	return WrapperTCP(network, address, d)
+}
+
+// WrapperTcpWithContext 创建一个带上下文的TCP连接
+func WrapperTcpWithContext(ctx context.Context, network, address string) (net.Conn, error) {
+	d := &net.Dialer{}
+	return WrapperTCPWithContext(ctx, network, address, d)
 }
 
 // WrapperTCP 根据配置创建TCP连接
@@ -39,6 +48,54 @@ func WrapperTCP(network, address string, forward *net.Dialer) (net.Conn, error) 
 	}
 
 	return conn, nil
+}
+
+// WrapperTCPWithContext 根据配置创建支持上下文的TCP连接
+func WrapperTCPWithContext(ctx context.Context, network, address string, forward *net.Dialer) (net.Conn, error) {
+	// 直连模式
+	if Socks5Proxy == "" {
+		conn, err := forward.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, fmt.Errorf(GetText("tcp_conn_failed"), err)
+		}
+		return conn, nil
+	}
+
+	// Socks5代理模式
+	dialer, err := Socks5Dialer(forward)
+	if err != nil {
+		return nil, fmt.Errorf(GetText("socks5_create_failed"), err)
+	}
+
+	// 创建一个结果通道来处理连接和取消
+	connChan := make(chan struct {
+		conn net.Conn
+		err  error
+	}, 1)
+
+	go func() {
+		conn, err := dialer.Dial(network, address)
+		select {
+		case <-ctx.Done():
+			if conn != nil {
+				conn.Close()
+			}
+		case connChan <- struct {
+			conn net.Conn
+			err  error
+		}{conn, err}:
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-connChan:
+		if result.err != nil {
+			return nil, fmt.Errorf(GetText("socks5_conn_failed"), result.err)
+		}
+		return result.conn, nil
+	}
 }
 
 // Socks5Dialer 创建Socks5代理拨号器
@@ -75,4 +132,60 @@ func Socks5Dialer(forward *net.Dialer) (proxy.Dialer, error) {
 	}
 
 	return dialer, nil
+}
+
+// WrapperTlsWithContext 创建一个通过代理的TLS连接
+func WrapperTlsWithContext(ctx context.Context, network, address string, tlsConfig *tls.Config) (net.Conn, error) {
+	// 直连模式
+	if Socks5Proxy == "" {
+		dialer := &net.Dialer{}
+
+		tcpConn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, fmt.Errorf("直连TCP连接失败: %v", err)
+		}
+
+		// 在TCP连接上进行TLS握手
+		tlsConn := tls.Client(tcpConn, tlsConfig)
+
+		// 使用ctx的deadline设置TLS握手超时
+		if deadline, ok := ctx.Deadline(); ok {
+			tlsConn.SetDeadline(deadline)
+		}
+
+		if err := tlsConn.Handshake(); err != nil {
+			tcpConn.Close()
+			return nil, fmt.Errorf("TLS握手失败: %v", err)
+		}
+
+		// 清除deadline，让上层代码自己管理超时
+		tlsConn.SetDeadline(time.Time{})
+
+		return tlsConn, nil
+	}
+
+	// Socks5代理模式
+	// 首先通过代理建立到目标的TCP连接
+	tcpConn, err := WrapperTcpWithContext(ctx, network, address)
+	if err != nil {
+		return nil, fmt.Errorf("通过代理建立TCP连接失败: %v", err)
+	}
+
+	// 在TCP连接上进行TLS握手
+	tlsConn := tls.Client(tcpConn, tlsConfig)
+
+	// 使用ctx的deadline设置TLS握手超时
+	if deadline, ok := ctx.Deadline(); ok {
+		tlsConn.SetDeadline(deadline)
+	}
+
+	if err := tlsConn.Handshake(); err != nil {
+		tcpConn.Close()
+		return nil, fmt.Errorf("TLS握手失败: %v", err)
+	}
+
+	// 清除deadline，让上层代码自己管理超时
+	tlsConn.SetDeadline(time.Time{})
+
+	return tlsConn, nil
 }

--- a/Core/PortInfo.go
+++ b/Core/PortInfo.go
@@ -407,8 +407,8 @@ func (i *Info) Write(msg []byte) error {
 	_, err := i.Conn.Write(msg)
 	if err != nil && strings.Contains(err.Error(), "close") {
 		i.Conn.Close()
-		// 连接关闭时重试
-		i.Conn, err = net.DialTimeout("tcp4", fmt.Sprintf("%s:%d", i.Address, i.Port), time.Duration(6)*time.Second)
+		// 连接关闭时重试 - 支持SOCKS5代理
+		i.Conn, err = Common.WrapperTcpWithTimeout("tcp", fmt.Sprintf("%s:%d", i.Address, i.Port), time.Duration(6)*time.Second)
 		if err == nil {
 			i.Conn.SetWriteDeadline(time.Now().Add(time.Second * time.Duration(WrTimeout)))
 			_, err = i.Conn.Write(msg)

--- a/Core/PortScan.go
+++ b/Core/PortScan.go
@@ -6,7 +6,6 @@ import (
 	"github.com/shadow1ng/fscan/Common"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -53,8 +52,8 @@ func EnhancedPortScan(hosts []string, ports string, timeout int64) []string {
 			g.Go(func() error {
 				defer sem.Release(1)
 
-				// 连接测试
-				conn, err := net.DialTimeout("tcp", addr, to)
+				// 连接测试 - 支持SOCKS5代理
+				conn, err := Common.WrapperTcpWithTimeout("tcp", addr, to)
 				if err != nil {
 					return nil
 				}

--- a/Plugins/ActiveMQ.go
+++ b/Plugins/ActiveMQ.go
@@ -3,11 +3,11 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // ActiveMQCredential 表示一个ActiveMQ凭据
@@ -213,8 +213,7 @@ func ActiveMQConn(ctx context.Context, info *Common.HostInfo, user string, pass 
 	addr := fmt.Sprintf("%s:%v", info.Host, info.Ports)
 
 	// 使用上下文创建带超时的连接
-	dialer := &net.Dialer{Timeout: time.Duration(Common.Timeout) * time.Second}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	conn, err := Common.WrapperTcpWithTimeout("tcp", addr, time.Duration(Common.Timeout)*time.Second)
 	if err != nil {
 		return false, err
 	}

--- a/Plugins/LDAP.go
+++ b/Plugins/LDAP.go
@@ -3,12 +3,12 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/go-ldap/ldap/v3"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/go-ldap/ldap/v3"
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // LDAPCredential 表示一个LDAP凭据
@@ -210,13 +210,8 @@ func tryLDAPCredential(ctx context.Context, info *Common.HostInfo, credential LD
 func LDAPConn(ctx context.Context, info *Common.HostInfo, user string, pass string) (bool, error) {
 	address := fmt.Sprintf("%s:%s", info.Host, info.Ports)
 
-	// 创建拨号器并设置超时
-	dialer := &net.Dialer{
-		Timeout: time.Duration(Common.Timeout) * time.Second,
-	}
-
 	// 使用上下文控制的拨号过程
-	conn, err := dialer.DialContext(ctx, "tcp", address)
+	conn, err := Common.WrapperTcpWithContext(ctx, "tcp", address)
 	if err != nil {
 		return false, err
 	}

--- a/Plugins/Modbus.go
+++ b/Plugins/Modbus.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // ModbusScanResult 表示 Modbus 扫描结果
@@ -77,8 +77,7 @@ func tryModbusScan(ctx context.Context, info *Common.HostInfo, timeoutSeconds in
 			// 在协程中执行扫描
 			go func() {
 				// 尝试建立连接
-				var d net.Dialer
-				conn, err := d.DialContext(connCtx, "tcp", target)
+				conn, err := Common.WrapperTcpWithContext(connCtx, "tcp", target)
 				if err != nil {
 					select {
 					case <-connCtx.Done():

--- a/Plugins/Mongodb.go
+++ b/Plugins/Mongodb.go
@@ -3,11 +3,11 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
 	"io"
-	"net"
 	"strings"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // MongodbScan 执行MongoDB未授权扫描
@@ -112,13 +112,8 @@ func MongodbUnauth(ctx context.Context, info *Common.HostInfo) (bool, error) {
 func checkMongoAuth(ctx context.Context, address string, packet []byte) (string, error) {
 	Common.LogDebug(fmt.Sprintf("建立MongoDB连接: %s", address))
 
-	// 创建连接超时上下文
-	connCtx, cancel := context.WithTimeout(ctx, time.Duration(Common.Timeout)*time.Second)
-	defer cancel()
-
 	// 使用带超时的连接
-	var d net.Dialer
-	conn, err := d.DialContext(connCtx, "tcp", address)
+	conn, err := Common.WrapperTcpWithTimeout("tcp", address, time.Duration(Common.Timeout)*time.Second)
 	if err != nil {
 		return "", fmt.Errorf("连接失败: %v", err)
 	}

--- a/Plugins/Neo4j.go
+++ b/Plugins/Neo4j.go
@@ -3,11 +3,12 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
-	"github.com/shadow1ng/fscan/Common"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // Neo4jCredential 表示一个Neo4j凭据
@@ -268,6 +269,9 @@ func Neo4jConn(info *Common.HostInfo, user string, pass string) (bool, error) {
 	config := func(c *neo4j.Config) {
 		c.SocketConnectTimeout = timeout
 		c.ConnectionAcquisitionTimeout = timeout
+
+		// 注意：Neo4j驱动可能不支持代理配置
+		// 如果需要代理支持，可能需要使用更底层的连接方式
 	}
 
 	var driver neo4j.Driver

--- a/Plugins/SMB2.go
+++ b/Plugins/SMB2.go
@@ -3,12 +3,12 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 
 	"github.com/hirochachacha/go-smb2"
 )
@@ -316,9 +316,8 @@ func trySmb2Credential(ctx context.Context, info *Common.HostInfo, credential Sm
 
 // Smb2Con 尝试SMB2连接并进行认证，检查共享访问权限
 func Smb2Con(ctx context.Context, info *Common.HostInfo, user string, pass string, hash []byte, hasprint bool) (flag bool, err error, shares []string) {
-	// 建立TCP连接，使用上下文提供的超时控制
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:445", info.Host))
+	// 建立TCP连接，使用socks代理支持
+	conn, err := Common.WrapperTcpWithTimeout("tcp", fmt.Sprintf("%s:445", info.Host), time.Duration(Common.Timeout)*time.Second)
 	if err != nil {
 		return false, fmt.Errorf("连接失败: %v", err), nil
 	}

--- a/Plugins/SMTP.go
+++ b/Plugins/SMTP.go
@@ -3,12 +3,12 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"net/smtp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // SmtpCredential 表示一个SMTP凭据
@@ -253,11 +253,7 @@ func SmtpConn(info *Common.HostInfo, user string, pass string, timeoutSeconds in
 	addr := fmt.Sprintf("%s:%s", host, port)
 
 	// 设置连接超时
-	dialer := &net.Dialer{
-		Timeout: timeout,
-	}
-
-	conn, err := dialer.Dial("tcp", addr)
+	conn, err := Common.WrapperTcpWithTimeout("tcp", addr, timeout)
 	if err != nil {
 		return false, err
 	}

--- a/Plugins/Telnet.go
+++ b/Plugins/Telnet.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/shadow1ng/fscan/Common"
 	"net"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // TelnetCredential 表示一个Telnet凭据
@@ -248,9 +249,8 @@ func tryTelnetCredential(ctx context.Context, info *Common.HostInfo, credential 
 
 // telnetConnWithContext 带上下文的Telnet连接尝试
 func telnetConnWithContext(ctx context.Context, info *Common.HostInfo, user, pass string) (bool, error) {
-	// 创建TCP连接(使用上下文控制)
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", info.Host, info.Ports))
+	// 创建TCP连接(使用支持context的socks代理)
+	conn, err := Common.WrapperTcpWithContext(ctx, "tcp", fmt.Sprintf("%s:%s", info.Host, info.Ports))
 	if err != nil {
 		return false, err
 	}

--- a/Plugins/VNC.go
+++ b/Plugins/VNC.go
@@ -3,11 +3,11 @@ package Plugins
 import (
 	"context"
 	"fmt"
-	"github.com/mitchellh/go-vnc"
-	"github.com/shadow1ng/fscan/Common"
-	"net"
 	"sync"
 	"time"
+
+	"github.com/mitchellh/go-vnc"
+	"github.com/shadow1ng/fscan/Common"
 )
 
 // VncCredential 表示VNC凭据
@@ -190,8 +190,7 @@ func VncConn(ctx context.Context, info *Common.HostInfo, pass string) (bool, err
 	timeout := time.Duration(Common.Timeout) * time.Second
 
 	// 使用带上下文的TCP连接
-	var d net.Dialer
-	conn, err := d.DialContext(ctx, "tcp", fmt.Sprintf("%s:%s", Host, Port))
+	conn, err := Common.WrapperTcpWithTimeout("tcp", fmt.Sprintf("%s:%s", Host, Port), timeout)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
解决 #65 中proxychains不支持golang程序的socks5代理问题

根据本程序帮助，Socks5理应代理TCP连接。
```
  -proxy string
        设置HTTP代理服务器
  -socks5 string
        设置Socks5代理(用于TCP连接,将影响超时设置)
```

<img width="1256" height="768" alt="image" src="https://github.com/user-attachments/assets/062a02d5-2c43-45b1-b9c7-1072d16c94b6" />

另外，部分漏洞插件的代理似乎未使用任何代理（HTTP、SOCKS5）