### PR TITLE
fix：尝试修复webtitle插件因body异常返回无法通过web端识别到打印机的问题

### DIFF
--- a/Plugins/WebTitle.go
+++ b/Plugins/WebTitle.go
@@ -313,7 +313,7 @@ func readResponseBody(resp *http.Response) ([]byte, error) {
 
 	// 读取内容
 	body, err := io.ReadAll(reader)
-	if err != nil {
+	if len(body) <= 0 && err != nil {
 		return nil, fmt.Errorf("读取响应内容失败: %w", err)
 	}
 


### PR DESCRIPTION
issue：内网扫描打印机管理页面，webtitle无法识别 #546