### PR TITLE
refactor: 统一控制台输出风格，使用统一的日志函数

### DIFF
--- a/Plugins/MS17010-Exp.go
+++ b/Plugins/MS17010-Exp.go
@@ -70,7 +70,7 @@ func MS17010EXP(info *Common.HostInfo) {
 
 	// 验证shellcode有效性
 	if len(sc) < 20 {
-		fmt.Println("无效的Shellcode")
+		Common.LogError("无效的Shellcode")
 		return
 	}
 

--- a/WebScan/lib/Client.go
+++ b/WebScan/lib/Client.go
@@ -256,7 +256,7 @@ func LoadMultiPoc(Pocs embed.FS, pocname string) []*Poc {
 		if p, err := LoadPoc(f, Pocs); err == nil {
 			pocs = append(pocs, p)
 		} else {
-			fmt.Printf("POC加载失败 %s: %v\n", f, err)
+			Common.LogError(fmt.Sprintf("POC加载失败 %s: %v", f, err))
 		}
 	}
 	return pocs
@@ -268,14 +268,14 @@ func LoadPoc(fileName string, Pocs embed.FS) (*Poc, error) {
 	// 读取POC文件内容
 	yamlFile, err := Pocs.ReadFile("pocs/" + fileName)
 	if err != nil {
-		fmt.Printf("POC文件读取失败 %s: %v\n", fileName, err)
+		Common.LogError(fmt.Sprintf("POC文件读取失败 %s: %v", fileName, err))
 		return nil, err
 	}
 
 	// 解析YAML内容
 	err = yaml.Unmarshal(yamlFile, p)
 	if err != nil {
-		fmt.Printf("POC解析失败 %s: %v\n", fileName, err)
+		Common.LogError(fmt.Sprintf("POC解析失败 %s: %v", fileName, err))
 		return nil, err
 	}
 	return p, err
@@ -285,7 +285,7 @@ func LoadPoc(fileName string, Pocs embed.FS) (*Poc, error) {
 func SelectPoc(Pocs embed.FS, pocname string) []string {
 	entries, err := Pocs.ReadDir("pocs")
 	if err != nil {
-		fmt.Printf("读取POC目录失败: %v\n", err)
+		Common.LogError(fmt.Sprintf("读取POC目录失败: %v", err))
 	}
 
 	var foundFiles []string
@@ -304,14 +304,14 @@ func LoadPocbyPath(fileName string) (*Poc, error) {
 	// 读取POC文件内容
 	data, err := os.ReadFile(fileName)
 	if err != nil {
-		fmt.Printf("POC文件读取失败 %s: %v\n", fileName, err)
+		Common.LogError(fmt.Sprintf("POC文件读取失败 %s: %v", fileName, err))
 		return nil, err
 	}
 
 	// 解析YAML内容
 	err = yaml.Unmarshal(data, p)
 	if err != nil {
-		fmt.Printf("POC解析失败 %s: %v\n", fileName, err)
+		Common.LogError(fmt.Sprintf("POC解析失败 %s: %v", fileName, err))
 		return nil, err
 	}
 	return p, err

--- a/WebScan/lib/Eval.go
+++ b/WebScan/lib/Eval.go
@@ -620,7 +620,7 @@ func reverseCheck(r *Reverse, timeout int64) bool {
 	isOK := bytes.Contains(resp.Body, []byte(`"message": "OK"`))
 
 	if hasData && isOK {
-		fmt.Println(apiURL)
+		Common.LogDebug(apiURL)
 		return true
 	}
 	return false


### PR DESCRIPTION
- 将 Plugins/MS17010-Exp.go 中的 fmt.Println 替换为 Common.LogError
- 将 WebScan/lib/Client.go 中的 POC 加载错误输出替换为 Common.LogError
- 将 WebScan/lib/Eval.go 中的调试输出替换为 Common.LogDebug

所有控制台输出现在通过统一的日志系统，确保格式一致性和可维护性。