### PR TITLE
fix: 修复高并发下自适应超时过低导致开放端口漏扫

### DIFF
--- a/common/i18n/locales/en.yaml
+++ b/common/i18n/locales/en.yaml
@@ -429,6 +429,12 @@ port_open_http:
   other: "Port open {{.Arg1}} [http](HTTP probe)"
 port_scan_no_alive_subnet:
   other: "Subnet probe found no alive subnets, skipping port scan"
+port_scan_timeout_retry:
+  other: "[PortScan] {{.Arg1}} adaptive timeout({{.Arg2}}) failed, retrying with full timeout({{.Arg3}})"
+port_scan_task_dropped:
+  other: "[PortScan] task dropped: {{.Arg1}} ({{.Arg2}}), port may be missed"
+port_scan_tasks_dropped_total:
+  other: "[PortScan] {{.Arg1}} tasks dropped total, these ports may be missed"
 network_rate_limited_pattern:
   other: "Rate limited"
 port_scan_debug_start:

--- a/common/i18n/locales/zh.yaml
+++ b/common/i18n/locales/zh.yaml
@@ -429,6 +429,12 @@ port_open_http:
   other: "端口开放 {{.Arg1}} [http](HTTP探测)"
 port_scan_no_alive_subnet:
   other: "网段预筛未发现存活子网，跳过端口扫描"
+port_scan_timeout_retry:
+  other: "[PortScan] {{.Arg1}} 自适应超时({{.Arg2}})失败，用完整超时({{.Arg3}})重试"
+port_scan_task_dropped:
+  other: "[PortScan] 任务被丢弃: {{.Arg1}} ({{.Arg2}})，该端口可能被漏扫"
+port_scan_tasks_dropped_total:
+  other: "[PortScan] 共有 {{.Arg1}} 个任务被丢弃，这些端口可能被漏扫"
 network_rate_limited_pattern:
   other: "发包受限"
 port_scan_debug_start:

--- a/core/adaptive_timeout.go
+++ b/core/adaptive_timeout.go
@@ -25,13 +25,25 @@ type AdaptiveTimeout struct {
 // NewAdaptiveTimeout 创建自适应超时计算器
 // maxTimeout: 用户配置的超时上限（即原始固定超时）
 func NewAdaptiveTimeout(maxTimeout time.Duration) *AdaptiveTimeout {
+	// minTO: 自适应超时下限，取 max(500ms, maxTimeout/5)
+	// 依据：高并发下 TCP 握手存在尾延迟（OS 调度抖动、backlog 溢出、端口竞争），
+	//       过低的下限会导致开放端口被误判为关闭（issue #503）
+	minTO := maxTimeout / 5
+	if minTO < 500*time.Millisecond {
+		minTO = 500 * time.Millisecond
+	}
 	return &AdaptiveTimeout{
 		samples: make([]float64, 64),
 		size:    64,
-		minTO:   100 * time.Millisecond,
+		minTO:   minTO,
 		maxTO:   maxTimeout,
 		warmup:  10,
 	}
+}
+
+// MaxTimeout 返回配置的最大超时值（用于超时重试时回退到完整超时）
+func (a *AdaptiveTimeout) MaxTimeout() time.Duration {
+	return a.maxTO
 }
 
 // Record 记录一次成功连接的 RTT

--- a/core/port_scan.go
+++ b/core/port_scan.go
@@ -290,6 +290,7 @@ func EnhancedPortScan(ctx context.Context, hosts []string, ports string, timeout
 // slidingWindowSchedule 滑动窗口调度器
 // ants.PoolWithFunc.Invoke 在池满时阻塞，天然提供反压，无需额外 semaphore
 func slidingWindowSchedule(iter *SocketIterator, pool *AdaptivePool, wg *sync.WaitGroup) {
+	var dropped int64
 	for {
 		host, port, ok := iter.Next()
 		if !ok {
@@ -304,11 +305,17 @@ func slidingWindowSchedule(iter *SocketIterator, pool *AdaptivePool, wg *sync.Wa
 		}
 		if err := pool.Invoke(task); err != nil {
 			wg.Done()
+			dropped++
+			common.LogError(i18n.Tr("port_scan_task_dropped", task.addr, err))
 		}
 	}
 
 	// 等待所有任务完成
 	wg.Wait()
+
+	if dropped > 0 {
+		common.LogError(i18n.Tr("port_scan_tasks_dropped_total", dropped))
+	}
 }
 
 // fmtPort 无分配的端口号格式化
@@ -327,8 +334,11 @@ func fmtPort(port int) string {
 	return string(buf[i:])
 }
 
-// connectWithRetry 带重试的TCP连接 - 只对资源耗尽错误重试
-func connectWithRetry(ctx context.Context, session *common.ScanSession, addr string, timeout time.Duration, maxRetries int) (net.Conn, error) {
+// connectWithRetry 带重试的TCP连接
+// - 资源耗尽错误：指数退避重试（maxRetries 次）
+// - 超时错误：用 fallbackTimeout（完整超时）重试一次，避免自适应超时过低导致开放端口被漏扫（issue #503）
+// - 其他错误（如 connection refused）：直接返回，端口确实关闭
+func connectWithRetry(ctx context.Context, session *common.ScanSession, addr string, timeout time.Duration, maxRetries int, fallbackTimeout time.Duration) (net.Conn, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
@@ -340,9 +350,19 @@ func connectWithRetry(ctx context.Context, session *common.ScanSession, addr str
 
 		lastErr = err
 
+		// 超时错误：用完整超时重试一次（自适应超时可能过低）
+		if isTimeoutError(err) && attempt == 0 && fallbackTimeout > timeout {
+			session.LogDebug(i18n.Tr("port_scan_timeout_retry", addr, timeout, fallbackTimeout))
+			conn, err = session.DialTCP(ctx, "tcp", addr, fallbackTimeout)
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+
 		// 只对资源耗尽类错误重试，端口关闭直接返回
 		if !isResourceExhaustedError(err) {
-			return nil, err
+			return nil, lastErr
 		}
 
 		// 记录资源耗尽错误
@@ -496,7 +516,7 @@ func scanSinglePort(ctx context.Context, host string, port int, addr string, ada
 	timeout := adaptiveTO.Timeout()
 	// 步骤1：建立连接
 	start := time.Now()
-	conn, err := connectWithRetry(ctx, session, addr, timeout, 2)
+	conn, err := connectWithRetry(ctx, session, addr, timeout, 2, adaptiveTO.MaxTimeout())
 	if err != nil {
 		rtt := time.Since(start)
 		switch {
@@ -527,7 +547,7 @@ func scanSinglePort(ctx context.Context, host string, port int, addr string, ada
 	if session.ProxyEnabled() && verifyMethod != "direct" {
 		_ = conn.Close()
 		// 重新建立干净的连接用于服务识别
-		conn, err = connectWithRetry(ctx, session, addr, timeout, 2)
+		conn, err = connectWithRetry(ctx, session, addr, timeout, 2, adaptiveTO.MaxTimeout())
 		if err != nil {
 			handleConnectionFailure(err, host, port, addr, failedCollector)
 			return


### PR DESCRIPTION
## 问题

Issue #503 反映 fscan 2.x 扫描本机时部分端口漏扫，而 1.8.4 不存在此问题。

## 原因

2.x 引入的 AdaptiveTimeout（自适应超时）在高并发场景下下限过低：

1. 扫描本机时 RTT 接近 0，自适应超时在 10 次采样后迅速降到 100ms 下限
2. 600+ 并发下 TCP 握手存在尾延迟（OS 调度抖动、backlog 溢出、端口竞争），部分开放端口的连接耗时超过 100ms
3. 超时错误不会被重试（connectWithRetry 只重试资源耗尽错误），开放端口被永久漏扫

## 修复

**1. 提高自适应超时下限**（core/adaptive_timeout.go）

minTO 从固定 100ms 改为 max(500ms, maxTimeout/5)：
- 默认 3s 超时：下限 100ms -> 600ms
- LAN 环境 1s 超时：下限 100ms -> 500ms

**2. 超时错误重试**（core/port_scan.go）

connectWithRetry 新增 fallbackTimeout 参数，连接超时时用完整超时再试一次，避免自适应超时过低导致误判。

**3. 任务丢弃日志**（core/port_scan.go）

slidingWindowSchedule 中 pool.Invoke 失败不再静默丢弃，改为记录日志和总计统计，方便排查漏扫。

## 测试

全部测试通过，包括自适应超时收敛测试验证新下限工作正常：

TestReal_AdaptiveTimeout_Convergence: 3s -> 600ms (20 samples)
TestIntegration_DualRTTTracking: AdaptiveTO=600ms, Ratio=1.00

Closes #503